### PR TITLE
Add setuptools build and reference packaging files

### DIFF
--- a/packaging/apksideloader.spec
+++ b/packaging/apksideloader.spec
@@ -1,0 +1,95 @@
+Name:           apksideloader
+Version:        0.1
+Release:        1%{?dist}
+Summary:        Tool to sideload Android packages onto Chromebooks
+
+%if "%{_vendor}" == "debbuild"
+# Maps to debian/control required Maintainer field
+Packager:       Stephen Gallagher <Stephen@gallagherhome.com>
+License:        GPL-3.0+
+%else
+License:        GPLv3+
+%endif
+URL:            https://github.com/sgallagher/apksideloader
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+
+%if "%{_vendor}" == "debbuild"
+BuildRequires:  python3-dev >= 3.7
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-deb-macros
+Requires:       python3-adb-shell
+Requires:       python3-click >= 7.0.0
+Requires:       python3-gi >= 3.30.4
+Requires:       python3-setuptools
+Requires(post): python3-minimal >= 3.7
+Requires(preun): python3-minimal >= 3.7
+%else
+BuildRequires:  python3-devel >= 3.7
+BuildRequires:  python3-setuptools
+
+# Enable Python dependency generation
+%{?python_enable_dependency_generator}
+
+%if %{undefined python_enable_dependency_generator}
+Requires:       python3dist(adb-shell)
+Requires:       python3dist(click) >= 7
+Requires:       python3dist(pygobject) >= 3.30.4
+Requires:       python3dist(setuptools)
+%endif
+%endif
+
+%description
+%{name} is a tool to sideload Android packages (APKs) onto
+devices running Google Chrome OS.
+
+%prep
+%autosetup -p1
+
+
+%build
+%py3_build
+
+
+%install
+%py3_install
+
+mkdir -p %{buildroot}%{_datadir}/applications
+mkdir -p %{buildroot}%{_datadir}/icons/hicolor/192x192
+
+# Install desktop file
+sed -e "s|@PREFIX@/@BINDIR@|%{_bindir}|g" \
+    data/com.gallagherhome.apksideloader.desktop.in \
+    > %{buildroot}%{_datadir}/applications/com.gallagherhome.apksideloader.desktop
+
+# Install icon
+install -pm 0644 ./data/icons/hicolor/192x192/android_icon.png \
+    %{buildroot}%{_datadir}/icons/hicolor/192x192/android_icon.png
+
+
+%files
+%if "%{_vendor}" == "debbuild"
+%license packaging/copyright
+%endif
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+%{python3_sitelib}/%{name}*
+%{_datadir}/applications/com.gallagherhome.apksideloader.desktop
+%{_datadir}/icons/hicolor/192x192/android_icon.png
+
+
+%if "%{_vendor}" == "debbuild"
+# Debian does install-time byte-compilation
+%post
+%{py3_bytecompile_post %{name}}
+
+%preun
+%{py3_bytecompile_preun %{name}}
+%endif
+
+
+%changelog
+* Thu Jun  4 2020 Neal Gompa <ngompa13@gmail.com>
+- Initial packaging

--- a/packaging/copyright
+++ b/packaging/copyright
@@ -1,0 +1,27 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: apksideloader
+Upstream-Contact: Stephen Gallagher <Stephen@gallagherhome.com>
+Source: http://github.com/sgallagher/apksideloader
+
+Files: *
+Copyright: Copyright 2020 Stephen Gallagher.
+License: GPL-3.0+
+ This program is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public
+ License as published by the Free Software Foundation; under
+ version 3 of the License, or (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be
+ useful, but WITHOUT ANY WARRANTY; without even the implied
+ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU General Public License for more
+ details.
+ .
+ You should have received a copy of the GNU General Public
+ License along with this package; if not, write to the Free
+ Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ Boston, MA  02110-1301 USA
+ .
+ On Debian systems, the full text of the GNU General Public
+ License version 3 can be found in the file
+ `/usr/share/common-licenses/GPL-3'.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,47 @@
+from setuptools import setup
+
+setup(
+    name="apksideloader",
+    version="0.1",
+    license="GPLv3+",
+    description="A tool to sideload Android packages onto Chromebooks",
+    keywords="android apk sideload",
+    # From https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # Development status
+        "Development Status :: 3 - Alpha",
+        # Target audience
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        # Type of software
+        "Topic :: System :: Installation/Setup",
+        "Topic :: System :: Software Distribution",
+        # Kind of software
+        "Environment :: Console",
+        "Environment :: X11 Applications :: GTK",
+        # License (must match license field)
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        # Operating systems supported
+        "Operating System :: POSIX",
+        "Operating System :: POSIX :: Linux",
+        # Supported Python versions
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+    ],
+    url="http://github.com/sgallagher/apksideloader",
+    author="Stephen Gallagher",
+    author_email="Stephen@gallagherhome.com",
+    packages=["apksideloader"],
+    include_package_data=True,
+    install_requires=[
+        "Click>=7.0.0",
+        "adb-shell",
+        "PyGObject>=3.30.4",
+    ],
+    entry_points={
+        "console_scripts": [
+            "apksideloader = apksideloader.cli:main",
+        ],
+    },
+)


### PR DESCRIPTION
This pull request adds a basic setuptools build, since Debian and derivatives do not support building Python software with PEP517/PEP518 stuff yet.

In addition, a reference RPM spec file is provided that will build for RPM and Debian based distributions.

To build for Debian 10, first grab `debbuild` and `debbuild-macros`:

```bash
echo 'deb http://download.opensuse.org/repositories/Debian:/debbuild/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/Debian:debbuild.list
sudo wget -nv https://download.opensuse.org/repositories/Debian:debbuild/Debian_10/Release.key -O "/etc/apt/trusted.gpg.d/Debian:debbuild.asc"
sudo apt update
sudo apt install debbuild debbuild-macros
```

Then you can set up `~/debbuild/{SPECS,SOURCES,SDEBS,DEBS,BUILD,BUILDROOT}`, put the files in the right place, and use `debbuild -ba apksideloader.spec` to build it.